### PR TITLE
Merge AK4 and AK8 PFCands

### DIFF
--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -2,15 +2,9 @@
 <use name="FWCore/MessageLogger"/>
 <library file="*.cc" name="PhysicsToolsNanoAODJMARPlugins">
   <use name="DataFormats/PatCandidates"/>
-  <use name="DataFormats/VertexReco"/>
   <use name="DataFormats/NanoAOD"/>
   <use name="CommonTools/Utils"/>
   <use name="RecoBTag/FeatureTools"/>
-  <use name="RecoJets/JetAlgorithms"/>
-  <use name="PhysicsTools/Pancakes"/>
   <use name="TrackingTools/Records"/>
-  <use name="roottmva"/>
-  <use name="fastjet"/>
-  <use name="fastjet-contrib"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/plugins/JetConstituentTableProducer.cc
+++ b/plugins/JetConstituentTableProducer.cc
@@ -17,6 +17,10 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include <unordered_map>
+#include <unordered_set>
 
 class JetConstituentTableProducer : public edm::stream::EDProducer<> {
 public:
@@ -26,19 +30,36 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void produce(edm::Event &, const edm::EventSetup &) override;
-
   typedef edm::Ptr<pat::PackedCandidate> CandidatePtr;
+  typedef CandidatePtr::key_type Key;
   typedef edm::View<pat::PackedCandidate> CandidateView;
   typedef reco::VertexCollection VertexCollection;
 
-  const std::string name_;
-  const StringCutObjectSelector<pat::Jet> jetCut_;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-  edm::EDGetTokenT<edm::View<pat::Jet>> jet_token_;
+  template <typename T>
+  T getval(const std::unordered_map<Key, T> &m, Key key, T fallback = 0) {
+    auto it = m.find(key);
+    return it == m.end() ? fallback : it->second;
+  }
+
+  std::vector<CandidatePtr> getDaughters(const pat::Jet &jet, bool isPuppi);
+
+  const std::string name_;
+  const bool check_indices_;
+
+  unsigned ncols_ = 0;
+  std::vector<std::string> jet_names_;
+  std::vector<bool> jet_ispuppi_;
+  std::vector<StringCutObjectSelector<pat::Jet>> jet_cuts_;
+  std::vector<edm::EDGetTokenT<edm::View<pat::Jet>>> jet_tokens_;
+  std::vector<std::string> npf_valuemap_names_;
+  std::vector<std::string> xref_table_names_;
+
   edm::EDGetTokenT<VertexCollection> vtx_token_;
   edm::EDGetTokenT<CandidateView> pfcand_token_;
 
+  std::vector<edm::Handle<edm::View<pat::Jet>>> jets_;
   edm::Handle<VertexCollection> vtxs_;
   edm::Handle<CandidateView> pfcands_;
   edm::ESHandle<TransientTrackBuilder> track_builder_;
@@ -49,12 +70,25 @@ private:
 //
 JetConstituentTableProducer::JetConstituentTableProducer(const edm::ParameterSet &iConfig)
     : name_(iConfig.getParameter<std::string>("name")),
-      jetCut_(iConfig.getParameter<std::string>("cut"), true),
-      jet_token_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+      check_indices_(iConfig.getParameter<bool>("check_indices")),
       vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
       pfcand_token_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("pf_candidates"))) {
+  const auto &pset = iConfig.getParameterSet("jets");
+  jet_names_ = pset.getParameterNames();
+  ncols_ = jet_names_.size();
+  for (const auto &jetname : jet_names_) {
+    const auto &p = pset.getParameterSet(jetname);
+    jet_ispuppi_.emplace_back(p.getParameter<bool>("isPuppi"));
+    jet_cuts_.emplace_back(p.getParameter<std::string>("cut"), true);
+    jet_tokens_.emplace_back(consumes<edm::View<pat::Jet>>(p.getParameter<edm::InputTag>("src")));
+  }
+
   produces<nanoaod::FlatTable>(name_);
-  produces<std::vector<CandidatePtr>>();
+  produces<std::vector<CandidatePtr>>("constituents");
+  for (const auto &jetname : jet_names_) {
+    produces<edm::ValueMap<int>>(npf_valuemap_names_.emplace_back(jetname + "Npfcand"));
+    produces<nanoaod::FlatTable>(xref_table_names_.emplace_back(jetname + "To" + name_));
+  }
 }
 
 JetConstituentTableProducer::~JetConstituentTableProducer() {}
@@ -62,79 +96,184 @@ JetConstituentTableProducer::~JetConstituentTableProducer() {}
 void JetConstituentTableProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // elements in all these collections must have the same order!
   auto outCands = std::make_unique<std::vector<CandidatePtr>>();
-  std::vector<int> jetIdx;
-  std::vector<float> btagEtaRel, btagPtRatio, btagPParRatio, btagSip3dVal, btagSip3dSig, btagJetDistVal;
+  std::vector<std::vector<int>> nPFCands(ncols_);
+  std::vector<std::vector<int>> dauIdx(ncols_);  // for each vector: size = sum(nPFcand) for all jets in the event
+  std::vector<std::vector<float>> btagEtaRel(ncols_), btagPtRatio(ncols_), btagPParRatio(ncols_), btagSip3dVal(ncols_),
+      btagSip3dSig(ncols_), btagJetDistVal(ncols_);  // size = outCands.size()
+
+  for (unsigned ic = 0; ic < ncols_; ++ic) {
+    jets_.emplace_back();
+    iEvent.getByToken(jet_tokens_[ic], jets_[ic]);
+    // nPFCands must have same size as the jet collection in all cases
+    nPFCands[ic] = std::vector<int>(jets_[ic]->size(), 0);
+  }
 
   iEvent.getByToken(vtx_token_, vtxs_);
   if (!vtxs_->empty()) {
-    auto jets = iEvent.getHandle(jet_token_);
     iEvent.getByToken(pfcand_token_, pfcands_);
     iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder_);
 
-    for (unsigned i_jet = 0; i_jet < jets->size(); ++i_jet) {
-      const auto &jet = jets->at(i_jet);
-      if (!jetCut_(jet))
-        continue;
+    std::vector<Key> kvec;                   // stores cand keys in an ordered vector
+    std::unordered_set<Key> kset;            // used to check for duplicates -- not adding to kvec if already in
+    std::unordered_map<Key, unsigned> kmap;  // map from cand's key to its index in the kvec
 
-      math::XYZVector jet_dir = jet.momentum().Unit();
-      GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+    // vmaps below: one for each jet collection
+    std::vector<std::vector<Key>> vvec_dauKeys(ncols_);
+    std::vector<std::unordered_map<Key, float>> vmap_btagEtaRel(ncols_), vmap_btagPtRatio(ncols_),
+        vmap_btagPParRatio(ncols_), vmap_btagSip3dVal(ncols_), vmap_btagSip3dSig(ncols_), vmap_btagJetDistVal(ncols_);
 
-      std::vector<CandidatePtr> daughters;
-      for (const auto &cand : jet.daughterPtrVector()) {
-        const auto *packed_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
-        assert(packed_cand != nullptr);
-        // remove particles w/ extremely low puppi weights (needed for 2017 MiniAOD)
-        if (packed_cand->puppiWeight() < 0.01)
+    for (unsigned ic = 0; ic < ncols_; ++ic) {
+      auto &v_dauKeys = vvec_dauKeys[ic];
+      auto &m_btagEtaRel = vmap_btagEtaRel[ic];
+      auto &m_btagPtRatio = vmap_btagPtRatio[ic];
+      auto &m_btagPParRatio = vmap_btagPParRatio[ic];
+      auto &m_btagSip3dVal = vmap_btagSip3dVal[ic];
+      auto &m_btagSip3dSig = vmap_btagSip3dSig[ic];
+      auto &m_btagJetDistVal = vmap_btagJetDistVal[ic];
+
+      for (unsigned i_jet = 0; i_jet < jets_[ic]->size(); ++i_jet) {
+        const auto &jet = jets_[ic]->at(i_jet);
+        if (!jet_cuts_[ic](jet)) {
           continue;
-        // get the original reco/packed candidate not scaled by the puppi weight
-        daughters.push_back(pfcands_->ptrAt(cand.key()));
-      }
-      // sort by original pt (not Puppi-weighted)
-      std::sort(daughters.begin(), daughters.end(), [](const auto &a, const auto &b) { return a->pt() > b->pt(); });
+        }
 
-      for (const auto &cand : daughters) {
-        outCands->push_back(cand);
-        jetIdx.push_back(i_jet);
-        if (cand->hasTrackDetails()){
-          btagbtvdeep::TrackInfoBuilder trkinfo(track_builder_);
-          trkinfo.buildTrackInfo(&(*cand), jet_dir, jet_ref_track_dir, vtxs_->at(0));
-          btagEtaRel.push_back(trkinfo.getTrackEtaRel());
-          btagPtRatio.push_back(trkinfo.getTrackPtRatio());
-          btagPParRatio.push_back(trkinfo.getTrackPParRatio());
-          btagSip3dVal.push_back(trkinfo.getTrackSip3dVal());
-          btagSip3dSig.push_back(trkinfo.getTrackSip3dSig());
-          btagJetDistVal.push_back(trkinfo.getTrackJetDistVal());
-        } else {
-          btagEtaRel.push_back(0);
-          btagPtRatio.push_back(0);
-          btagPParRatio.push_back(0);
-          btagSip3dVal.push_back(0);
-          btagSip3dSig.push_back(0);
-          btagJetDistVal.push_back(0);
+        math::XYZVector jet_dir = jet.momentum().Unit();
+        GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+
+        auto daughters = getDaughters(jet, jet_ispuppi_[ic]);
+        nPFCands[ic][i_jet] = daughters.size();
+        for (const auto &cand : daughters) {
+          auto result = kset.insert(cand.key());
+          if (result.second) {
+            // if cand.key is not in kset
+            kmap[cand.key()] = kvec.size();  // new val will be added to the end of kvec
+            kvec.push_back(cand.key());
+          }
+          v_dauKeys.push_back(cand.key());  // add for the current jet collection
+          if (cand->hasTrackDetails()) {
+            btagbtvdeep::TrackInfoBuilder trkinfo(track_builder_);
+            trkinfo.buildTrackInfo(&(*cand), jet_dir, jet_ref_track_dir, vtxs_->at(0));
+            m_btagEtaRel[cand.key()] = trkinfo.getTrackEtaRel();
+            m_btagPtRatio[cand.key()] = trkinfo.getTrackPtRatio();
+            m_btagPParRatio[cand.key()] = trkinfo.getTrackPParRatio();
+            m_btagSip3dVal[cand.key()] = trkinfo.getTrackSip3dVal();
+            m_btagSip3dSig[cand.key()] = trkinfo.getTrackSip3dSig();
+            m_btagJetDistVal[cand.key()] = trkinfo.getTrackJetDistVal();
+          } else {
+            m_btagEtaRel[cand.key()] = 0;
+            m_btagPtRatio[cand.key()] = 0;
+            m_btagPParRatio[cand.key()] = 0;
+            m_btagSip3dVal[cand.key()] = 0;
+            m_btagSip3dSig[cand.key()] = 0;
+            m_btagJetDistVal[cand.key()] = 0;
+          }
+        }
+      }  // end jet loop
+    }
+
+    // use pfcand key to determine the index in the output pfcand collection/table
+    for (unsigned ic = 0; ic < ncols_; ++ic) {
+      for (const auto &key : vvec_dauKeys[ic]) {
+        dauIdx[ic].push_back(kmap.at(key));
+      }
+    }
+
+    for (const auto &key : kvec) {
+      outCands->push_back(pfcands_->ptrAt(key));
+      // fill variables
+      for (unsigned ic = 0; ic < ncols_; ++ic) {
+        // fill 0 if this pfcand does not appear in this jet collection
+        btagEtaRel[ic].push_back(getval(vmap_btagEtaRel[ic], key));
+        btagPtRatio[ic].push_back(getval(vmap_btagPtRatio[ic], key));
+        btagPParRatio[ic].push_back(getval(vmap_btagPParRatio[ic], key));
+        btagSip3dVal[ic].push_back(getval(vmap_btagSip3dVal[ic], key));
+        btagSip3dSig[ic].push_back(getval(vmap_btagSip3dSig[ic], key));
+        btagJetDistVal[ic].push_back(getval(vmap_btagJetDistVal[ic], key));
+      }
+    }
+
+    // for testing the implementation -- turn if off for production
+    if (check_indices_) {
+      for (unsigned ic = 0; ic < ncols_; ++ic) {
+        unsigned idau_global = 0;
+        for (unsigned i_jet = 0; i_jet < jets_[ic]->size(); ++i_jet) {
+          const auto &jet = jets_[ic]->at(i_jet);
+          if (nPFCands[ic][i_jet] == 0)
+            continue;
+          auto daughters = getDaughters(jet, jet_ispuppi_[ic]);
+          for (unsigned idau = 0; idau < daughters.size(); ++idau) {
+            if (daughters[idau].key() != outCands->at(dauIdx[ic].at(idau_global)).key()) {
+              throw cms::Exception("RuntimeError") << "Inconsistent index for jet collection " << jet_names_[ic];
+            }
+            ++idau_global;
+          }
         }
       }
-    }  // end jet loop
+    }  // check_indices_
   }
 
   auto candTable = std::make_unique<nanoaod::FlatTable>(outCands->size(), name_, false);
   // We fill from here only stuff that cannot be created with the SimpleFlatTableProducer
-  candTable->addColumn<int>("jetIdx", jetIdx, "Index of the parent jet", nanoaod::FlatTable::IntColumn);
-  candTable->addColumn<float>("btagEtaRel", btagEtaRel, "btagEtaRel", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagPtRatio", btagPtRatio, "btagPtRatio", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagPParRatio", btagPParRatio, "btagPParRatio", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagSip3dVal", btagSip3dVal, "btagSip3dVal", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagSip3dSig", btagSip3dSig, "btagSip3dSig", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagJetDistVal", btagJetDistVal, "btagJetDistVal", nanoaod::FlatTable::FloatColumn, 10);
+  for (unsigned ic = 0; ic < ncols_; ++ic) {
+    auto suffix = "_" + jet_names_[ic];
+    auto doc = "(" + jet_names_[ic] + ")";
+    candTable->addColumn<float>(
+        "btagEtaRel" + suffix, btagEtaRel[ic], "btagEtaRel" + doc, nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>(
+        "btagPtRatio" + suffix, btagPtRatio[ic], "btagPtRatio" + doc, nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>(
+        "btagPParRatio" + suffix, btagPParRatio[ic], "btagPParRatio" + doc, nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>(
+        "btagSip3dVal" + suffix, btagSip3dVal[ic], "btagSip3dVal" + doc, nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>(
+        "btagSip3dSig" + suffix, btagSip3dSig[ic], "btagSip3dSig" + doc, nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>(
+        "btagJetDistVal" + suffix, btagJetDistVal[ic], "btagJetDistVal" + doc, nanoaod::FlatTable::FloatColumn, 10);
+  }
 
   iEvent.put(std::move(candTable), name_);
-  iEvent.put(std::move(outCands));
+  iEvent.put(std::move(outCands), "constituents");
+  for (unsigned ic = 0; ic < ncols_; ++ic) {
+    auto npfMap = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler filler(*npfMap);
+    filler.insert(jets_[ic], nPFCands[ic].begin(), nPFCands[ic].end());
+    filler.fill();
+    iEvent.put(std::move(npfMap), npf_valuemap_names_[ic]);
+
+    auto xrefTable = std::make_unique<nanoaod::FlatTable>(dauIdx[ic].size(), xref_table_names_[ic], false);
+    xrefTable->addColumn<int>("candIdx",
+                              dauIdx[ic],
+                              "Indices of the jet constitutes in the PFCand table. Use nPFCands in the jet table to "
+                              "separate these indices for each jet.",
+                              nanoaod::FlatTable::IntColumn);
+    iEvent.put(std::move(xrefTable), xref_table_names_[ic]);
+  }
+}
+
+std::vector<JetConstituentTableProducer::CandidatePtr> JetConstituentTableProducer::getDaughters(const pat::Jet &jet,
+                                                                                                 bool isPuppi) {
+  std::vector<CandidatePtr> daughters;
+  for (const auto &cand : jet.daughterPtrVector()) {
+    const auto *packed_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
+    assert(packed_cand != nullptr);
+    // remove particles w/ extremely low puppi weights (needed for 2017 MiniAOD)
+    if (isPuppi && packed_cand->puppiWeight() < 0.01)
+      continue;
+    // get the original reco/packed candidate not scaled by the puppi weight
+    daughters.push_back(pfcands_->ptrAt(cand.key()));
+  }
+  // sort by original pt (not Puppi weighted)
+  std::sort(daughters.begin(), daughters.end(), [](const auto &a, const auto &b) { return a->pt() > b->pt(); });
+  return daughters;
 }
 
 void JetConstituentTableProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src", edm::InputTag("slimmedJetsAK8"));
-  desc.add<std::string>("name", "AK8PFCands");
-  desc.add<std::string>("cut", "pt()>170");
+  desc.add<std::string>("name", "JetPFCands");
+  desc.add<bool>("check_indices", false);
+  edm::ParameterSetDescription jets;
+  jets.setAllowAnything();
+  desc.add<edm::ParameterSetDescription>("jets", jets);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
   desc.add<edm::InputTag>("pf_candidates", edm::InputTag("packedPFCandidates"));
   descriptions.addWithDefaultLabel(desc);

--- a/python/addPFCands_cff.py
+++ b/python/addPFCands_cff.py
@@ -1,46 +1,65 @@
 import FWCore.ParameterSet.Config as cms
-from  PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.common_cff import *
+
 
 def addPFCands(process, runOnMC=False, onlyAK4=False, onlyAK8=False):
-    process.customizedPFCandsTask = cms.Task( )
+    process.customizedPFCandsTask = cms.Task()
     process.schedule.associate(process.customizedPFCandsTask)
 
-    process.customAK8ConstituentsTable = cms.EDProducer("JetConstituentTableProducer",
-                                                        src = cms.InputTag("finalJetsAK8"),
-                                                        cut = cms.string("pt()>170"),
-                                                        name = cms.string("FatJetPFCands"))
+    addAK4 = not onlyAK8
+    addAK8 = not onlyAK4
+    jets = cms.PSet()
+    if addAK4:
+        jets.Jet = cms.PSet(
+            src = cms.InputTag("linkedObjects","jets"),
+            isPuppi = cms.bool(False),
+            cut = cms.string('pt > 20'),
+            )
+    if addAK8:
+        jets.FatJet = cms.PSet(
+            src = cms.InputTag('updatedJetsAK8WithUserData'),
+            isPuppi = cms.bool(True),
+            cut = cms.string('pt > 170'),
+            )
 
-    process.customAK8ConstituentsExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-                                       src = cms.InputTag("customAK8ConstituentsTable"),
-                                       cut = cms.string(""), #we should not filter after pruning
-                                       name = cms.string("FatJetPFCands"),
-                                       doc = cms.string("interesting particles from AK8 jets"),
-                                       singleton = cms.bool(False), # the number of entries is variable
-                                       extension = cms.bool(True), # this is the extension table for the AK8 constituents
-                                       variables = cms.PSet(CandVars,
-                                                            puppiWeight = Var("puppiWeight()", float, doc="Puppi weight",precision=10),
-                                                            puppiWeightNoLep = Var("puppiWeightNoLep()", float, doc="Puppi weight removing leptons",precision=10),
-                                                            vtxChi2 = Var("?hasTrackDetails()?vertexChi2():-1", float, doc="vertex chi2",precision=10),
-                                                            trkChi2 = Var("?hasTrackDetails()?pseudoTrack().normalizedChi2():-1", float, doc="normalized trk chi2", precision=10),
-                                                            dz = Var("?hasTrackDetails()?dz():-1", float, doc="pf dz", precision=10),
-                                                            dzErr = Var("?hasTrackDetails()?dzError():-1", float, doc="pf dz err", precision=10),
-                                                            d0 = Var("?hasTrackDetails()?dxy():-1", float, doc="pf d0", precision=10),
-                                                            d0Err = Var("?hasTrackDetails()?dxyError():-1", float, doc="pf d0 err", precision=10),
-                                                            pvAssocQuality = Var("pvAssociationQuality()", int, doc="primary vertex association quality"),
-                                                            lostInnerHits = Var("lostInnerHits()", int, doc="lost inner hits"),
-                                                            trkQuality = Var("?hasTrackDetails()?pseudoTrack().qualityMask():0", int, doc="track quality mask"),
-                                                         )
-                                    )
+    process.jetConstituentsTable = cms.EDProducer("JetConstituentTableProducer",
+                                                  jets = jets,
+                                                  name = cms.string("PFCands"),
+                                                  check_indices = cms.bool(False),  # for debugging
+                                                  )
 
-    process.customAK4ConstituentsTable = process.customAK8ConstituentsTable.clone( src = 'finalJets', cut = 'pt()>20', name = 'JetPFCands'  )
-    process.customAK4ConstituentsExtTable = process.customAK8ConstituentsExtTable.clone( src = 'customAK4ConstituentsTable', name = 'JetPFCands', doc = 'interesting particles from AK4 jets'  )
+    process.jetConstituentsExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+        src = cms.InputTag("jetConstituentsTable", "constituents"),
+        cut = cms.string(""), #we should not filter after pruning
+        name = cms.string("PFCands"),
+        doc = cms.string("interesting particles from jets"),
+        singleton = cms.bool(False), # the number of entries is variable
+        extension = cms.bool(True), # this is the extension table for the AK8 constituents
+        variables = cms.PSet(CandVars,
+            puppiWeight = Var("puppiWeight()", float, doc="Puppi weight", precision=10),
+            puppiWeightNoLep = Var("puppiWeightNoLep()", float, doc="Puppi weight removing leptons", precision=10),
+            vtxChi2 = Var("?hasTrackDetails()?vertexChi2():-1", float, doc="vertex chi2", precision=10),
+            trkChi2 = Var("?hasTrackDetails()?pseudoTrack().normalizedChi2():-1", float, doc="normalized trk chi2", precision=10),
+            dz = Var("dz()", float, doc="pf dz", precision=10),
+            dzErr = Var("?hasTrackDetails()?dzError():-1", float, doc="pf dz err", precision=10),
+            d0 = Var("dxy()", float, doc="pf d0", precision=10),
+            d0Err = Var("?hasTrackDetails()?dxyError():-1", float, doc="pf d0 err", precision=10),
+            pvAssocQuality = Var("pvAssociationQuality()", int, doc="primary vertex association quality"),
+            lostInnerHits = Var("lostInnerHits()", int, doc="lost inner hits"),
+            trkQuality = Var("?hasTrackDetails()?pseudoTrack().qualityMask():0", int, doc="track quality mask"),
+            )
+        )
 
-    if not onlyAK4:
-        process.customizedPFCandsTask.add(process.customAK8ConstituentsTable)
-        process.customizedPFCandsTask.add(process.customAK8ConstituentsExtTable)
-    if not onlyAK8:
-        process.customizedPFCandsTask.add(process.customAK4ConstituentsTable)
-        process.customizedPFCandsTask.add(process.customAK4ConstituentsExtTable)
+    process.customizedPFCandsTask.add(process.jetConstituentsTable, process.jetConstituentsExtTable)
+
+    if addAK4:
+        ext = getattr(process.jetTable, 'externalVariables', cms.PSet())
+        ext.nPFCand = ExtVar(cms.InputTag("jetConstituentsTable", "JetNpfcand"), int, doc="number of PFCands stored in the PFCands table")
+        process.jetTable.externalVariables = ext
+    if addAK8:
+        ext = getattr(process.fatJetTable, 'externalVariables', cms.PSet())
+        ext.nPFCand = ExtVar(cms.InputTag("jetConstituentsTable", "FatJetNpfcand"), int, doc="number of PFCands stored in the PFCands table")
+        process.fatJetTable.externalVariables = ext
 
     if runOnMC:
 
@@ -70,10 +89,10 @@ def addPFCands(process, runOnMC=False, onlyAK4=False, onlyAK8=False):
                                                             doc = cms.string("interesting gen particles from AK4 jets"),
                                                             )
 
-        if not onlyAK8:
+        if addAK4:
             process.customizedPFCandsTask.add(process.genJetsAK4Constituents)
             process.customizedPFCandsTask.add(process.genJetsAK4ParticleTable)
-        if not onlyAK4:
+        if addAK8:
             process.customizedPFCandsTask.add(process.genJetsAK8Constituents)
             process.customizedPFCandsTask.add(process.genJetsAK8ParticleTable)
 


### PR DESCRIPTION
Rewrote `JetConstituentTableProducer` to take multiple jet collections, merge the constituents, and output a single PFCands table without duplicates. 
For Puppi jets, the producer goes back to the original unweighted PackedCandidate (using `ptr.key()`) and saved the original p4 and the puppi weights. 
For going from jet to pfcands: a `nPFCand` is stored for each jet, and then a flattened pfcand index list is stored per event as NanoAOD does not support `vector<vector<int>>`. These branches are called e.g.,`JetToPFCands` and `FatJetToPFCands`.
