### PR TITLE
Cross-linking in custom NANO

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For **UL** 2016, 2017 and 2018 data and MC **NanoAODv6** according to the [XPOG 
 cmsrel  CMSSW_10_6_5
 cd  CMSSW_10_6_5/src
 cmsenv
+git cms-merge-topic laurenhay:setmerger_10_6_5
 git clone git@github.com:cms-jet/NanoAODJMAR.git -b dev_106x PhysicsTools/NanoAODJMAR
 scram b -j 10
 cd PhysicsTools/NanoAODJMAR/test

--- a/plugins/JetConstituentTableProducer.cc
+++ b/plugins/JetConstituentTableProducer.cc
@@ -12,12 +12,15 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
 #include "RecoBTag/FeatureTools/interface/TrackInfoBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 
+template<typename T>
 class JetConstituentTableProducer : public edm::stream::EDProducer<> {
 public:
   explicit JetConstituentTableProducer(const edm::ParameterSet &);
@@ -28,83 +31,82 @@ public:
 private:
   void produce(edm::Event &, const edm::EventSetup &) override;
 
-  typedef edm::Ptr<pat::PackedCandidate> CandidatePtr;
-  typedef edm::View<pat::PackedCandidate> CandidateView;
   typedef reco::VertexCollection VertexCollection;
 
   const std::string name_;
-  const StringCutObjectSelector<pat::Jet> jetCut_;
+  const bool readBtag_;
 
-  edm::EDGetTokenT<edm::View<pat::Jet>> jet_token_;
+  edm::EDGetTokenT<edm::View<T>> jet_token_;
   edm::EDGetTokenT<VertexCollection> vtx_token_;
-  edm::EDGetTokenT<CandidateView> pfcand_token_;
+  edm::EDGetTokenT<reco::CandidateView> cand_token_;
 
   edm::Handle<VertexCollection> vtxs_;
-  edm::Handle<CandidateView> pfcands_;
+  edm::Handle<reco::CandidateView> cands_;
   edm::ESHandle<TransientTrackBuilder> track_builder_;
 };
 
 //
 // constructors and destructor
 //
-JetConstituentTableProducer::JetConstituentTableProducer(const edm::ParameterSet &iConfig)
+template< typename T>
+JetConstituentTableProducer<T>::JetConstituentTableProducer(const edm::ParameterSet &iConfig)
     : name_(iConfig.getParameter<std::string>("name")),
-      jetCut_(iConfig.getParameter<std::string>("cut"), true),
-      jet_token_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("src"))),
+      readBtag_(iConfig.getParameter<bool>("readBtag")),
+      jet_token_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("jets"))),
       vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
-      pfcand_token_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("pf_candidates"))) {
+      cand_token_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("candidates"))) {
   produces<nanoaod::FlatTable>(name_);
-  produces<std::vector<CandidatePtr>>();
+  produces<std::vector<reco::CandidatePtr>>();
 }
 
-JetConstituentTableProducer::~JetConstituentTableProducer() {}
+template< typename T>
+JetConstituentTableProducer<T>::~JetConstituentTableProducer() {}
 
-void JetConstituentTableProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+template< typename T>
+void JetConstituentTableProducer<T>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // elements in all these collections must have the same order!
-  auto outCands = std::make_unique<std::vector<CandidatePtr>>();
-  std::vector<int> jetIdx;
+  auto outCands = std::make_unique<std::vector<reco::CandidatePtr>>();
+  std::vector<int> jetIdx, candIdx;
   std::vector<float> btagEtaRel, btagPtRatio, btagPParRatio, btagSip3dVal, btagSip3dSig, btagJetDistVal;
+  auto jets = iEvent.getHandle(jet_token_);
+  iEvent.getByToken(cand_token_, cands_);
 
-  iEvent.getByToken(vtx_token_, vtxs_);
-  if (!vtxs_->empty()) {
-    auto jets = iEvent.getHandle(jet_token_);
-    iEvent.getByToken(pfcand_token_, pfcands_);
+  if(readBtag_){
+    iEvent.getByToken(vtx_token_, vtxs_);
     iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", track_builder_);
+  }
 
-    for (unsigned i_jet = 0; i_jet < jets->size(); ++i_jet) {
-      const auto &jet = jets->at(i_jet);
-      if (!jetCut_(jet))
-        continue;
+  for (unsigned i_jet = 0; i_jet < jets->size(); ++i_jet) {
+    const auto &jet = jets->at(i_jet);
+    math::XYZVector jet_dir = jet.momentum().Unit();
+    GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+    
+    std::vector<reco::CandidatePtr> const & daughters = jet.daughterPtrVector();
 
-      math::XYZVector jet_dir = jet.momentum().Unit();
-      GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
-
-      std::vector<CandidatePtr> daughters;
-      for (const auto &cand : jet.daughterPtrVector()) {
-        const auto *packed_cand = dynamic_cast<const pat::PackedCandidate *>(&(*cand));
-        assert(packed_cand != nullptr);
-        // remove particles w/ extremely low puppi weights (needed for 2017 MiniAOD)
-        if (packed_cand->puppiWeight() < 0.01)
-          continue;
-        // get the original reco/packed candidate not scaled by the puppi weight
-        daughters.push_back(pfcands_->ptrAt(cand.key()));
+    for (const auto &cand : daughters) {
+      auto candPtrs = cands_->ptrs();
+      auto candInNewList = std::find( candPtrs.begin(), candPtrs.end(), cand );
+      if ( candInNewList == candPtrs.end() ) {
+	std::cout << "Cannot find candidate : " << cand.id() << ", " << cand.key() << ", pt = " << cand->pt() << std::endl;
+	continue;
       }
-      // sort by original pt (not Puppi-weighted)
-      std::sort(daughters.begin(), daughters.end(), [](const auto &a, const auto &b) { return a->pt() > b->pt(); });
-
-      for (const auto &cand : daughters) {
-        outCands->push_back(cand);
-        jetIdx.push_back(i_jet);
-        if (cand->hasTrackDetails()){
-          btagbtvdeep::TrackInfoBuilder trkinfo(track_builder_);
-          trkinfo.buildTrackInfo(&(*cand), jet_dir, jet_ref_track_dir, vtxs_->at(0));
-          btagEtaRel.push_back(trkinfo.getTrackEtaRel());
-          btagPtRatio.push_back(trkinfo.getTrackPtRatio());
-          btagPParRatio.push_back(trkinfo.getTrackPParRatio());
-          btagSip3dVal.push_back(trkinfo.getTrackSip3dVal());
-          btagSip3dSig.push_back(trkinfo.getTrackSip3dSig());
-          btagJetDistVal.push_back(trkinfo.getTrackJetDistVal());
-        } else {
+      outCands->push_back(cand);
+      jetIdx.push_back(i_jet);
+      candIdx.push_back( candInNewList - candPtrs.begin() );
+      if (readBtag_ && !vtxs_->empty()) {
+	if ( cand.isNull() ) continue;
+	auto const *packedCand = dynamic_cast <pat::PackedCandidate const *>(cand.get());
+	if ( packedCand == nullptr ) continue;
+	if ( packedCand && packedCand->hasTrackDetails()){
+	  btagbtvdeep::TrackInfoBuilder trkinfo(track_builder_);
+	  trkinfo.buildTrackInfo(&(*packedCand), jet_dir, jet_ref_track_dir, vtxs_->at(0));
+	  btagEtaRel.push_back(trkinfo.getTrackEtaRel());
+	  btagPtRatio.push_back(trkinfo.getTrackPtRatio());
+	  btagPParRatio.push_back(trkinfo.getTrackPParRatio());
+	  btagSip3dVal.push_back(trkinfo.getTrackSip3dVal());
+	  btagSip3dSig.push_back(trkinfo.getTrackSip3dSig());
+	  btagJetDistVal.push_back(trkinfo.getTrackJetDistVal());
+	} else {
           btagEtaRel.push_back(0);
           btagPtRatio.push_back(0);
           btagPParRatio.push_back(0);
@@ -118,26 +120,33 @@ void JetConstituentTableProducer::produce(edm::Event &iEvent, const edm::EventSe
 
   auto candTable = std::make_unique<nanoaod::FlatTable>(outCands->size(), name_, false);
   // We fill from here only stuff that cannot be created with the SimpleFlatTableProducer
+  candTable->addColumn<int>("candIdx", candIdx, "Index in the candidate list", nanoaod::FlatTable::IntColumn);
   candTable->addColumn<int>("jetIdx", jetIdx, "Index of the parent jet", nanoaod::FlatTable::IntColumn);
-  candTable->addColumn<float>("btagEtaRel", btagEtaRel, "btagEtaRel", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagPtRatio", btagPtRatio, "btagPtRatio", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagPParRatio", btagPParRatio, "btagPParRatio", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagSip3dVal", btagSip3dVal, "btagSip3dVal", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagSip3dSig", btagSip3dSig, "btagSip3dSig", nanoaod::FlatTable::FloatColumn, 10);
-  candTable->addColumn<float>("btagJetDistVal", btagJetDistVal, "btagJetDistVal", nanoaod::FlatTable::FloatColumn, 10);
-
+  if (readBtag_) {
+    candTable->addColumn<float>("btagEtaRel", btagEtaRel, "btagEtaRel", nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>("btagPtRatio", btagPtRatio, "btagPtRatio", nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>("btagPParRatio", btagPParRatio, "btagPParRatio", nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>("btagSip3dVal", btagSip3dVal, "btagSip3dVal", nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>("btagSip3dSig", btagSip3dSig, "btagSip3dSig", nanoaod::FlatTable::FloatColumn, 10);
+    candTable->addColumn<float>("btagJetDistVal", btagJetDistVal, "btagJetDistVal", nanoaod::FlatTable::FloatColumn, 10);
+  }
   iEvent.put(std::move(candTable), name_);
   iEvent.put(std::move(outCands));
 }
 
-void JetConstituentTableProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+template< typename T>
+void JetConstituentTableProducer<T>::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src", edm::InputTag("slimmedJetsAK8"));
-  desc.add<std::string>("name", "AK8PFCands");
-  desc.add<std::string>("cut", "pt()>170");
+  desc.add<std::string>("name", "JetPFCands");
+  desc.add<bool>("readBtag", true);
+  desc.add<edm::InputTag>("jets", edm::InputTag("slimmedJetsAK8"));
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-  desc.add<edm::InputTag>("pf_candidates", edm::InputTag("packedPFCandidates"));
+  desc.add<edm::InputTag>("candidates", edm::InputTag("packedPFCandidates"));
   descriptions.addWithDefaultLabel(desc);
 }
 
-DEFINE_FWK_MODULE(JetConstituentTableProducer);
+typedef JetConstituentTableProducer<pat::Jet> PatJetConstituentTableProducer;
+typedef JetConstituentTableProducer<reco::GenJet> GenJetConstituentTableProducer;
+
+DEFINE_FWK_MODULE(PatJetConstituentTableProducer);
+DEFINE_FWK_MODULE(GenJetConstituentTableProducer);

--- a/python/addPFCands_cff.py
+++ b/python/addPFCands_cff.py
@@ -7,11 +7,11 @@ def addPFCands(process, runOnMC=False, onlyAK4=False, onlyAK8=False):
 
     process.finalJetsAK8Constituents = cms.EDProducer("PatJetConstituentPtrSelector",
                                             src = cms.InputTag("finalJetsAK8"),
-                                            cut = cms.string("pt > 170.0")
+                                            cut = cms.string("")
                                             )
     process.finalJetsAK4Constituents = cms.EDProducer("PatJetConstituentPtrSelector",
                                             src = cms.InputTag("finalJets"),
-                                            cut = cms.string("pt > 30.0")
+                                            cut = cms.string("")
                                             )
     if onlyAK4:
         candList = cms.VInputTag(cms.InputTag("finalJetsAK4Constituents", "constituents"))
@@ -46,21 +46,33 @@ def addPFCands(process, runOnMC=False, onlyAK4=False, onlyAK8=False):
                                                             trkQuality = Var("?hasTrackDetails()?pseudoTrack().qualityMask():0", int, doc="track quality mask"),
                                                          )
                                     )
-    
+    process.customAK8ConstituentsTable = cms.EDProducer("PatJetConstituentTableProducer",
+                                                        candidates = cms.InputTag("finalJetsConstituents"),
+                                                        #candidates = cms.InputTag("packedPFCandidates"),
+                                                        jets = cms.InputTag("finalJetsAK8"),
+                                                        name = cms.string("JetPFCandsAK8"))
+    process.customAK4ConstituentsTable = cms.EDProducer("PatJetConstituentTableProducer",
+                                                        #candidates = cms.InputTag("packedPFCandidates"),
+                                                        candidates = cms.InputTag("finalJetsConstituents"),
+                                                        jets = cms.InputTag("finalJets"),
+                                                        name = cms.string("JetPFCandsAK4"))
+
     process.customizedPFCandsTask.add(process.finalJetsConstituents)
     process.customizedPFCandsTask.add(process.customConstituentsExtTable)
-
+    process.customizedPFCandsTask.add(process.customAK8ConstituentsTable)
+    process.customizedPFCandsTask.add(process.customAK4ConstituentsTable)
+    
     if runOnMC:
 
         process.genJetsAK8Constituents = cms.EDProducer("GenJetPackedConstituentPtrSelector",
                                                     src = cms.InputTag("slimmedGenJetsAK8"),
-                                                    cut = cms.string("pt > 100.0")
+                                                    cut = cms.string("")
                                                     )
 
       
         process.genJetsAK4Constituents = process.genJetsAK8Constituents.clone(
                                                     src = cms.InputTag("slimmedGenJets"),
-                                                    cut = cms.string("pt > 20.0")
+                                                    cut = cms.string("")
                                                     )
         if onlyAK4:
             genCandList = cms.VInputTag(cms.InputTag("genJetsAK4Constituents", "constituents"))
@@ -85,7 +97,21 @@ def addPFCands(process, runOnMC=False, onlyAK4=False, onlyAK8=False):
                                                          variables = cms.PSet(CandVars
                                                                           )
                                                      )
+        process.genAK8ConstituentsTable = cms.EDProducer("GenJetConstituentTableProducer",
+                                                         candidates = cms.InputTag("genJetsConstituents"),
+                                                         #candidates = cms.InputTag("packedGenParticles"),
+                                                         jets = cms.InputTag("slimmedGenJetsAK8"),
+                                                         name = cms.string("GenJetCandsAK8"),
+                                                         readBtag = cms.bool(False))
+        process.genAK4ConstituentsTable = cms.EDProducer("GenJetConstituentTableProducer",
+                                                         candidates = cms.InputTag("genJetsConstituents"),
+                                                         #candidates = cms.InputTag("packedGenParticles"),
+                                                         jets = cms.InputTag("slimmedGenJets"),
+                                                         name = cms.string("GenJetCandsAK4"),
+                                                         readBtag = cms.bool(False))
         process.customizedPFCandsTask.add(process.genJetsConstituents)
         process.customizedPFCandsTask.add(process.genJetsParticleTable)
+        process.customizedPFCandsTask.add(process.genAK8ConstituentsTable)
+        process.customizedPFCandsTask.add(process.genAK4ConstituentsTable)
       
     return process

--- a/test/nano106X_on_mini106X_2017_mc_NANO.py
+++ b/test/nano106X_on_mini106X_2017_mc_NANO.py
@@ -73,7 +73,7 @@ from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
 #Setup FWK for multithreaded
-process.options.numberOfThreads=cms.untracked.uint32(2)
+process.options.numberOfThreads=cms.untracked.uint32(1)
 process.options.numberOfStreams=cms.untracked.uint32(0)
 process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
 


### PR DESCRIPTION
Adding cross-linking between Candidates and Jets in custom NANOAOD. Works for AK4+AK8, and PF+GEN. 